### PR TITLE
fix(loader): update old class name and bump version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ compileJava   {
 }
 
 group 'com.jayfella'
-version '0.0.18'
+version '0.0.19'
 
 repositories {
     jcenter()

--- a/src/main/groovy/com/jayfella/devkit/gradle/JmeDevKitGradlePlugin.groovy
+++ b/src/main/groovy/com/jayfella/devkit/gradle/JmeDevKitGradlePlugin.groovy
@@ -65,7 +65,7 @@ class JmeDevKitGradlePlugin implements Plugin<Project> {
     private void configureTasks() {
 
         project.task("runSdk", type: JavaExec) {
-            main = "com.jayfella.importer.Main"
+            main = "com.jayfella.devkit.Main"
             classpath = project.sourceSets.main.runtimeClasspath
         }
     }

--- a/src/main/groovy/com/jayfella/devkit/gradle/JmeDevKitGradlePlugin.groovy
+++ b/src/main/groovy/com/jayfella/devkit/gradle/JmeDevKitGradlePlugin.groovy
@@ -73,7 +73,7 @@ class JmeDevKitGradlePlugin implements Plugin<Project> {
     private void configureDependencies() {
 
         // include the devkit as a dependency
-        Dependency dep = project.dependencies.create("com.jayfella:jme-swing-devkit:1.0.6")
+        Dependency dep = project.dependencies.create("com.jayfella:jme-swing-devkit:1.0.8")
         project.dependencies.add("runtimeOnly", dep)
 
     }


### PR DESCRIPTION
Update the old package name in run script in order to run the proper class in the new jme-swing-devkit version